### PR TITLE
2026-DFES: route scenario colours through theme classes

### DIFF
--- a/2026-DFES/index.html
+++ b/2026-DFES/index.html
@@ -281,8 +281,8 @@
 				<p>Together with ERM and our stakeholders we model five distinct pathways to 2050. Four reach net zero by different routes. One does not &mdash; it shows what business as usual would look like.</p>
 			</div>
 			<div class="scenario-grid">
-				<article class="scen-card">
-					<div class="topbar" style="background:#ce0037"></div>
+				<article class="scen-card" data-scenario="npg-reference-scenario">
+					<div class="topbar npg-reference-scenario"></div>
 					<div class="scen-eye">Reference</div>
 					<h3>NPg Reference Scenario</h3>
 					<span class="nz-pill yes"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>Net zero by 2050</span>
@@ -293,8 +293,8 @@
 						<div class="scen-stat"><span class="k">More renewables by 2050</span><span class="v">3.4&times;</span></div>
 					</div>
 				</article>
-				<article class="scen-card">
-					<div class="topbar" style="background:#b70539"></div>
+				<article class="scen-card" data-scenario="holistic-transition">
+					<div class="topbar holistic-transition"></div>
 					<div class="scen-eye">Holistic</div>
 					<h3>Holistic Transition</h3>
 					<span class="nz-pill yes"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>Net zero by 2050</span>
@@ -305,8 +305,8 @@
 						<div class="scen-stat"><span class="k">More renewables by 2050</span><span class="v">3.4&times;</span></div>
 					</div>
 				</article>
-				<article class="scen-card">
-					<div class="topbar" style="background:#e40046"></div>
+				<article class="scen-card" data-scenario="electric-engagement">
+					<div class="topbar electric-engagement"></div>
 					<div class="scen-eye">Electric</div>
 					<h3>Electric Engagement</h3>
 					<span class="nz-pill yes"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>Net zero by 2050</span>
@@ -317,8 +317,8 @@
 						<div class="scen-stat"><span class="k">More renewables by 2050</span><span class="v">3.4&times;</span></div>
 					</div>
 				</article>
-				<article class="scen-card">
-					<div class="topbar" style="background:#651d32"></div>
+				<article class="scen-card" data-scenario="hydrogen-evolution">
+					<div class="topbar hydrogen-evolution"></div>
 					<div class="scen-eye">Hydrogen</div>
 					<h3>Hydrogen Evolution</h3>
 					<span class="nz-pill yes"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>Net zero by 2050</span>
@@ -329,8 +329,8 @@
 						<div class="scen-stat"><span class="k">More renewables by 2050</span><span class="v">2.9&times;</span></div>
 					</div>
 				</article>
-				<article class="scen-card">
-					<div class="topbar" style="background:#494949"></div>
+				<article class="scen-card" data-scenario="falling-behind">
+					<div class="topbar falling-behind"></div>
 					<div class="scen-eye">Falling Behind</div>
 					<h3>Falling Behind</h3>
 					<span class="nz-pill no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>Misses 2050</span>

--- a/2026-DFES/resources/app.css
+++ b/2026-DFES/resources/app.css
@@ -2,11 +2,13 @@
 
 * { box-sizing: border-box; }
 html, body { margin: 0; padding: 0; }
+html { color-scheme: light; }
 body {
   font-family: var(--font-body);
   color: var(--text-color-1);
   background: var(--background-color);
   -webkit-font-smoothing: antialiased;
+  -webkit-tap-highlight-color: transparent;
 }
 img { display: block; max-width: 100%; }
 button { font-family: inherit; cursor: pointer; border: 0; background: none; }
@@ -59,7 +61,7 @@ a { color: inherit; }
   text-transform: uppercase;
   transition: background var(--dur-normal) var(--ease-std);
 }
-.utility-bar .powercut:hover { background: var(--black-100); color: var(--white); }
+@media (hover: hover) { .utility-bar .powercut:hover { background: var(--black-100); color: var(--white); } }
 .utility-bar .powercut svg { width: 14px; height: 14px; }
 
 /* Site header */
@@ -68,7 +70,7 @@ a { color: inherit; }
   border-bottom: 1px solid var(--navy-10);
   position: sticky;
   top: 0;
-  z-index: 50;
+  z-index: 1050; /* above Leaflet controls */
 }
 .site-header .holder {
   display: flex;
@@ -199,13 +201,13 @@ a { color: inherit; }
 }
 .btn:active { transform: translateY(1px); }
 .btn--primary { background: var(--white); color: var(--black-100); }
-.btn--primary:hover { background: var(--black-100); color: var(--white); }
+@media (hover: hover) { .btn--primary:hover { background: var(--black-100); color: var(--white); } }
 .btn--ghost-on-red { background: transparent; color: var(--white); border-color: rgba(255,255,255,0.55); }
-.btn--ghost-on-red:hover { background: var(--white); color: var(--red-100); border-color: var(--white); }
+@media (hover: hover) { .btn--ghost-on-red:hover { background: var(--white); color: var(--red-100); border-color: var(--white); } }
 .btn--dark { background: var(--black-100); color: var(--white); }
-.btn--dark:hover { background: var(--red-100); color: var(--white); }
+@media (hover: hover) { .btn--dark:hover { background: var(--red-100); color: var(--white); } }
 .btn--outline { background: transparent; color: var(--black-100); border-color: var(--black-100); }
-.btn--outline:hover { background: var(--black-100); color: var(--white); }
+@media (hover: hover) { .btn--outline:hover { background: var(--black-100); color: var(--white); } }
 .btn--sm { padding: 9px 16px; font-size: 13px; gap: 6px; }
 
 /* Hero animated network, design-system reference. The integration
@@ -331,16 +333,22 @@ a { color: inherit; }
   padding: 12px;
   border-radius: var(--r-sm);
   border: 1.5px solid var(--navy-10);
-  background: var(--white);
+  background-color: var(--white) !important;
+  background-image: none !important;
   text-align: left;
   cursor: pointer;
   transition: border-color var(--dur-fast), background var(--dur-fast);
+  appearance: none;
+  -webkit-appearance: none;
+  -webkit-tap-highlight-color: transparent;
 }
-.scenario-card:hover { border-color: var(--black-100); }
+@media (hover: hover) { .scenario-card:hover { border-color: var(--black-100); } }
 .scenario-card.active {
   border-color: var(--black-100);
-  background: var(--white);
-  box-shadow: inset 0 0 0 1px var(--black-100);
+  background-color: var(--white) !important;
+  background-image: none !important;
+  outline: 1px solid var(--black-100);
+  outline-offset: -1px;
 }
 .scenario-card .swatch {
   width: 18px; height: 18px; border-radius: 999px;
@@ -459,9 +467,9 @@ a { color: inherit; }
   justify-content: center;
   transition: background var(--dur-fast);
 }
-.icon-btn:hover { background: var(--red-100); }
+@media (hover: hover) { .icon-btn:hover { background: var(--red-100); } }
 .icon-btn.ghost { background: var(--white); color: var(--black-100); border: 1.5px solid var(--navy-20); }
-.icon-btn.ghost:hover { background: var(--black-5); }
+@media (hover: hover) { .icon-btn.ghost:hover { background: var(--black-5); } }
 .icon-btn svg { width: 14px; height: 14px; }
 
 .scrubber {
@@ -589,7 +597,7 @@ a { color: inherit; }
   font-weight: 600;
   color: var(--black-100);
 }
-.map-zoom button:hover { background: var(--black-5); }
+@media (hover: hover) { .map-zoom button:hover { background: var(--black-5); } }
 .map-zoom button + button { border-top: 1px solid var(--navy-10); }
 
 .map-search {
@@ -769,7 +777,7 @@ a { color: inherit; }
   transition: transform var(--dur-normal) var(--ease-std), border-color var(--dur-normal) var(--ease-std);
   cursor: pointer;
 }
-.scen-card:hover { transform: translateY(-3px); border-color: var(--black-100); }
+@media (hover: hover) { .scen-card:hover { transform: translateY(-3px); border-color: var(--black-100); } }
 .scen-card .topbar {
   height: 6px;
   margin: -24px -24px 0 -24px;
@@ -985,9 +993,9 @@ a { color: inherit; }
   color: var(--black-100);
 }
 .mode-calm .btn--primary { background: var(--black-100); color: var(--white); }
-.mode-calm .btn--primary:hover { background: var(--red-100); }
+@media (hover: hover) { .mode-calm .btn--primary:hover { background: var(--red-100); } }
 .mode-calm .btn--ghost-on-red { color: var(--black-100); border-color: var(--black-100); }
-.mode-calm .btn--ghost-on-red:hover { background: var(--black-100); color: var(--white); border-color: var(--black-100); }
+@media (hover: hover) { .mode-calm .btn--ghost-on-red:hover { background: var(--black-100); color: var(--white); border-color: var(--black-100); } }
 .mode-calm .hero::after {
   background: radial-gradient(ellipse at 80% 30%, rgba(206,0,55,0.05), transparent 60%);
 }
@@ -1039,6 +1047,7 @@ body {
 	background: var(--background-color);
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
+	-webkit-tap-highlight-color: transparent;
 }
 button { font-family: inherit; cursor: pointer; border: 0; background: none; }
 a { color: inherit; }
@@ -1092,7 +1101,7 @@ a { color: inherit; }
 	transition: background var(--dur-normal) var(--ease-std);
 	margin-left: 0; /* override .utility-bar a */
 }
-.utility-bar .powercut:hover { background: var(--black-100); color: var(--white); }
+@media (hover: hover) { .utility-bar .powercut:hover { background: var(--black-100); color: var(--white); } }
 .utility-bar .powercut svg { width: 14px; height: 14px; }
 
 
@@ -1102,7 +1111,7 @@ a { color: inherit; }
 	border-bottom: 1px solid var(--navy-10);
 	position: sticky;
 	top: 0;
-	z-index: 50;
+	z-index: 1050; /* above Leaflet controls */
 }
 .site-header .holder {
 	display: flex;
@@ -1169,13 +1178,13 @@ a { color: inherit; }
 }
 .btn:active { transform: translateY(1px); }
 .btn--primary { background: var(--white); color: var(--black-100); }
-.btn--primary:hover { background: var(--black-100); color: var(--white); }
+@media (hover: hover) { .btn--primary:hover { background: var(--black-100); color: var(--white); } }
 .btn--ghost-on-red { background: transparent; color: var(--white); border-color: rgba(255,255,255,0.55); }
-.btn--ghost-on-red:hover { background: var(--white); color: var(--red-100); border-color: var(--white); }
+@media (hover: hover) { .btn--ghost-on-red:hover { background: var(--white); color: var(--red-100); border-color: var(--white); } }
 .btn--dark { background: var(--black-100); color: var(--white); }
-.btn--dark:hover { background: var(--red-100); color: var(--white); }
+@media (hover: hover) { .btn--dark:hover { background: var(--red-100); color: var(--white); } }
 .btn--outline { background: transparent; color: var(--black-100); border-color: var(--black-100); }
-.btn--outline:hover { background: var(--black-100); color: var(--white); }
+@media (hover: hover) { .btn--outline:hover { background: var(--black-100); color: var(--white); } }
 .btn--sm { padding: 9px 16px; font-size: 13px; gap: 6px; }
 
 
@@ -1214,10 +1223,12 @@ a { color: inherit; }
    (warm-maroon) rather than the design-system default black;
    keeps the CTA feeling part of the NPg palette in the dark footer. */
 .site-footer .btn--primary { color: var(--black-100); }
-.site-footer .btn--primary:hover {
-	background: var(--warm-maroon);
-	color: var(--white);
-	text-decoration: none;
+@media (hover: hover) {
+	.site-footer .btn--primary:hover {
+		background: var(--warm-maroon);
+		color: var(--white);
+		text-decoration: none;
+	}
 }
 
 .footer-top {
@@ -1479,6 +1490,15 @@ a { color: inherit; }
 @media (max-width: 560px) {
 	.stats-strip .holder { grid-template-columns: 1fr; }
 }
+.stats-strip .stat-scenario .value { line-height: 1.1; }
+.stats-strip .scenario-pill {
+	display: inline-block;
+	max-width: 100%;
+	padding: 4px 14px;
+	border-radius: var(--r-sm);
+	border: 1.5px solid rgba(255, 255, 255, 0.4);
+	font-size: 30px;
+}
 
 
 /* === Workspace (map area), theme-a === */
@@ -1551,16 +1571,23 @@ a { color: inherit; }
 	padding: 8px 10px;
 	border-radius: var(--r-sm);
 	border: 1.5px solid var(--navy-10);
-	background: var(--white);
+	background-color: var(--white) !important;
+	background-image: none !important;
 	text-align: left;
 	cursor: pointer;
 	transition: border-color var(--dur-fast), background var(--dur-fast);
 	font-family: var(--font-body);
+	appearance: none;
+	-webkit-appearance: none;
+	-webkit-tap-highlight-color: transparent;
 }
-.scenario-card:hover { border-color: var(--black-100); }
+@media (hover: hover) { .scenario-card:hover { border-color: var(--black-100); } }
 .scenario-card.active {
 	border-color: var(--black-100);
-	box-shadow: inset 0 0 0 1px var(--black-100);
+	background-color: var(--white) !important;
+	background-image: none !important;
+	outline: 1px solid var(--black-100);
+	outline-offset: -1px;
 }
 .scenario-card .swatch {
 	display: block;
@@ -1725,14 +1752,14 @@ a { color: inherit; }
 	padding: 0;
 	font-size: 0; /* hide any text content (existing buttons have ▶/⏸ glyphs) */
 }
-.icon-btn:hover:not(:disabled) { background: var(--red-100); }
+@media (hover: hover) { .icon-btn:hover:not(:disabled) { background: var(--red-100); } }
 .icon-btn:disabled { opacity: 0.4; cursor: not-allowed; }
 .icon-btn.ghost {
 	background: var(--white);
 	color: var(--black-100);
 	border: 1.5px solid var(--navy-20);
 }
-.icon-btn.ghost:hover:not(:disabled) { background: var(--black-5); }
+@media (hover: hover) { .icon-btn.ghost:hover:not(:disabled) { background: var(--black-5); } }
 .icon-btn svg { width: 14px; height: 14px; display: block; }
 
 /* Scrubber, custom track/fill/thumb on top of the existing <input range> */
@@ -1846,7 +1873,7 @@ a { color: inherit; }
 	transition: background var(--dur-fast);
 	font-family: var(--font-body);
 }
-#scenario #download button:hover { background: var(--red-100); }
+@media (hover: hover) { #scenario #download button:hover { background: var(--red-100); } }
 #scenario #download button svg { width: 14px; height: 14px; }
 
 /* Workspace responsive */
@@ -2178,9 +2205,11 @@ a { color: inherit; }
 	overflow: hidden;
 	transition: transform var(--dur-normal) var(--ease-std), border-color var(--dur-normal) var(--ease-std);
 }
-.scen-card:hover {
-	transform: translateY(-3px);
-	border-color: var(--black-100);
+@media (hover: hover) {
+	.scen-card:hover {
+		transform: translateY(-3px);
+		border-color: var(--black-100);
+	}
 }
 .scen-card .topbar {
 	height: 6px;

--- a/2026-DFES/resources/controls.js
+++ b/2026-DFES/resources/controls.js
@@ -58,16 +58,11 @@
 			opts.forEach(function (opt) {
 				var name = opt.value;
 				var isActive = opt.selected;
-				// Pull colour and net-zero status from the live FES object.
-				var color = '#000';
-				if (window.dfes && dfes.scenarios && dfes.scenarios[name]) {
-					color = dfes.scenarios[name].color || '#000';
-				}
 				// Net-zero: hand-mapped here too (same list as stats-strip.js).
 				var nz = !/counterfactual|falling.?behind/i.test(name);
 				html += '<button type="button" class="scenario-card' + (isActive ? ' active' : '') +
 					'" data-value="' + escapeAttr(name) + '">' +
-					'<span class="swatch" style="background:' + escapeAttr(color) + '"></span>' +
+					'<span class="swatch ' + escapeAttr(scenarioClass(name)) + '"></span>' +
 					'<div class="name">' + escapeHtml(name) + '</div>' +
 					'<span class="nz ' + (nz ? 'yes' : 'no') + '">' +
 					(nz ? checkSvg() + 'Net zero ‘50' : crossSvg() + 'Misses target') +
@@ -216,6 +211,12 @@
 	}
 	function crossSvg() {
 		return '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" width="10" height="10" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg> ';
+	}
+	function scenarioClass(name) {
+		if (window.dfes && dfes.scenarios && dfes.scenarios[name] && dfes.scenarios[name].css) {
+			return dfes.scenarios[name].css;
+		}
+		return String(name).replace(/[^_a-zA-Z0-9-]/g, '-').toLowerCase();
 	}
 
 	function init() {

--- a/2026-DFES/resources/stats-strip.js
+++ b/2026-DFES/resources/stats-strip.js
@@ -23,6 +23,13 @@
 		'Counterfactual': false
 	};
 
+	function scenarioClass(name) {
+		if (window.dfes && dfes.scenarios && dfes.scenarios[name] && dfes.scenarios[name].css) {
+			return dfes.scenarios[name].css;
+		}
+		return String(name).replace(/[^_a-zA-Z0-9-]/g, '-').toLowerCase();
+	}
+
 	function fmt(v) {
 		if (v == null || isNaN(v)) return '—';
 		var abs = Math.abs(v);
@@ -116,8 +123,12 @@
 		var $nzDesc = root.querySelector('.stat-netzero .desc');
 
 		if ($scenarioVal) {
-			$scenarioVal.textContent = o.scenario;
-			$scenarioVal.style.color = scenario.color || 'var(--white)';
+			$scenarioVal.textContent = '';
+			$scenarioVal.style.color = '';
+			var pill = document.createElement('span');
+			pill.className = 'scenario-pill ' + scenarioClass(o.scenario);
+			pill.textContent = o.scenario;
+			$scenarioVal.appendChild(pill);
 		}
 		if ($scenarioDesc) $scenarioDesc.textContent = scenarioTagline(o.scenario);
 


### PR DESCRIPTION
2026-DFES: Picks up @slowe's three review comments on #102 

change to scenario colours through theme classes. Cards and the picker use the scenario theme class so colours come from data/scenarios.json instead of hard-coded values in index.html and controls.js. 

The stats-strip scenario name renders as a coloured pill rather than painting the text in scenario.color, so dark scenarios (Falling Behind) stay readable on the dark strip. 

Bumped .site-header z-index 50 to 1050 so the sticky header stays above Leaflet map controls when scrolled. 

Also picked up some iOS Safari issues after testing. Some touch-state fixes to stop buttons staying grey after interacting.