### PR TITLE
2026-DFES: white text on scenario picker card hover for contrast

### DIFF
--- a/2026-DFES/resources/app.css
+++ b/2026-DFES/resources/app.css
@@ -2348,3 +2348,4 @@ a { color: inherit; }
 @media (max-width: 1100px) {
 	.callout-grid { grid-template-columns: 1fr; }
 }
+@media (hover: hover) { .scenario-card:not(.active):hover .name, .scenario-card:not(.active):hover .nz.yes, .scenario-card:not(.active):hover .nz.no { color: var(--white); } }


### PR DESCRIPTION
On desktop the picker cards turn dark grey on hover but the card text stayed dark, leaving it hard to read. Skips the already- selected (.active) card since its background stays white.