### PR TITLE
Pre-launch tweaks

### DIFF
--- a/2026-DFES/data/graphs/index.json
+++ b/2026-DFES/data/graphs/index.json
@@ -55,14 +55,14 @@
 		"yaxis-label": "Annual peak demand (GW)",
 		"left": 50
 	},{
-		"title":"Network peak demand breakdown - NPg Reference Scenario (MW)",
+		"title":"Network peak demand breakdown - Holistic Transition (MW)",
 		"csv":"NetworkAnnualGrossPeakDemandBreakdown_ReferenceScenario_MW.csv",
 		"svg":"graph-annual-peak-demand-breakdown.svg",
 		"tooltip":"{{x}}: {{y}} MW",
 		"yaxis-label": "Annual gross peak demand (MW)",
 		"left": 50
 	},{
-		"title":"Network energy consumption breakdown - NPg Reference Scenario (TWh)",
+		"title":"Network energy consumption breakdown - Holistic Transition (TWh)",
 		"csv":"NetworkEnergyConsumptionBreakdown_ReferenceScenario_TWh.csv",
 		"svg":"graph-energy-consumption-breakdown.svg",
 		"tooltip":"{{x}}: {{y}} TWh",
@@ -76,14 +76,14 @@
 		"yaxis-label": "Energy consumption (TWh)",
 		"left": 60
 	},{
-		"title":"Additional industrial peak demand breakdown - NPg Reference Scenario (MW)",
+		"title":"Additional industrial peak demand breakdown - Holistic Transition (MW)",
 		"csv":"IndustryAdditionalPeakDemandBreakdown_NPgReferenceScenario_MW.csv",
 		"svg":"graph-industry-additional-peak-demand-planning-scenario.svg",
 		"tooltip":"{{x}}: {{y}} MW",
 		"yaxis-label": "Peak demand (MW)",
 		"left": 70
 	},{
-		"title":"Additional industrial energy consumption breakdown - NPg Reference Scenario (TWh)",
+		"title":"Additional industrial energy consumption breakdown - Holistic Transition (TWh)",
 		"csv":"IndustryAdditionalEnergyConsumptionBreakdown_NPgReferenceScenario_TWh.csv",
 		"tooltip":"{{x}}: {{y}} TWh",
 		"svg":"graph-industry-additional-energy-consumption-planning-scenario.svg",

--- a/2026-DFES/embed.html
+++ b/2026-DFES/embed.html
@@ -33,7 +33,7 @@
 	<meta name="twitter:site" content="@Northpowergrid" />
 	<meta name="twitter:url" property="og:url" content="https://northernpowergrid.github.io/dfes/2026-DFES/embed.html" />
 	<meta name="twitter:title" property="og:title" content="NorthernPowerGrid Future Energy Scenarios 2026" />
-	<meta name="twitter:description" property="og:description" content="Northern Powergrid's potential future scenarios, a regionalised interpretation of the 2026 National Grid future energy net zero compliant pathways in the transitional Regional Energy Strategic Plan (tRESP). Falling Behind comes from FES 2025. The Northern Powergrid Reference Scenario follows Holistic Transition." />
+	<meta name="twitter:description" property="og:description" content="Northern Powergrid's potential future scenarios are aligned to NESO's transitional Regional Energy Strategic Plan (tRESP). These are all net zero compliant pathways." />
 	<meta name="twitter:image" property="og:image" content="https://northernpowergrid.github.io/dfes/2026-DFES/screenshot.png" />
 </head>
 <body class="embed-page">
@@ -42,17 +42,10 @@
 	     or similar. Just the workspace + action pills; no chrome that would
 	     conflict with a host page. -->
 
-	<div class="warning tallpadded">
-		<div class="holder">
-			<h2>WARNING</h2>
-			<p>This page is currently <em>under development</em>. It contains placeholder parameters, scenarios, data, and text.<br />The real DFES 2026 data will be included here later.</p>
-		</div>
-	</div>
-
 	<div class="b6-bg" id="scenario">
 		<div class="intro tallpadded b5-bg">
 			<div class="holder">
-				<p>Northern Powergrid's potential future scenarios, a regionalised interpretation of the 2026 National Grid future energy net zero compliant pathways in the transitional Regional Energy Strategic Plan (tRESP). Falling Behind comes from FES 2025. The Northern Powergrid Reference Scenario follows Holistic Transition.</p>
+				<p>Northern Powergrid's potential future scenarios are aligned to NESO's transitional Regional Energy Strategic Plan (tRESP). These are all net zero compliant pathways.</p>
 			</div>
 		</div>
 		<div class="message"></div>

--- a/2026-DFES/graphs-embed.html
+++ b/2026-DFES/graphs-embed.html
@@ -911,11 +911,11 @@
       </header>
       <nav class="g-mini-toc" aria-label="Network demand graphs">
 <a href="#figure-7" class="g-mini-toc-item"><span>7</span> Annual peak demand (with ToUT) (GW)</a>
-<a href="#figure-8" class="g-mini-toc-item"><span>8</span> Network peak demand breakdown - NPg Reference Scenario (MW)</a>
-<a href="#figure-9" class="g-mini-toc-item"><span>9</span> Network energy consumption breakdown - NPg Reference Scenario (TWh)</a>
+<a href="#figure-8" class="g-mini-toc-item"><span>8</span> Network peak demand breakdown - Holistic Transition (MW)</a>
+<a href="#figure-9" class="g-mini-toc-item"><span>9</span> Network energy consumption breakdown - Holistic Transition (TWh)</a>
 <a href="#figure-10" class="g-mini-toc-item"><span>10</span> Annual network energy consumption (TWh)</a>
-<a href="#figure-11" class="g-mini-toc-item"><span>11</span> Additional industrial peak demand breakdown - NPg Reference Scenario (MW)</a>
-<a href="#figure-12" class="g-mini-toc-item"><span>12</span> Additional industrial energy consumption breakdown - NPg Reference Scenario (TWh)</a>
+<a href="#figure-11" class="g-mini-toc-item"><span>11</span> Additional industrial peak demand breakdown - Holistic Transition (MW)</a>
+<a href="#figure-12" class="g-mini-toc-item"><span>12</span> Additional industrial energy consumption breakdown - Holistic Transition (TWh)</a>
       </nav>
       <div class="g-figures">
 <article class="g-figure" id="figure-7" data-fig-num="7">
@@ -1073,11 +1073,11 @@
 <article class="g-figure" id="figure-8" data-fig-num="8">
       <header class="g-figure-head">
         <div class="g-figure-num">Figure 8</div>
-        <h3 class="g-figure-title">Network peak demand breakdown - NPg Reference Scenario (MW)</h3>
+        <h3 class="g-figure-title">Network peak demand breakdown - Holistic Transition (MW)</h3>
       </header>
       <div class="g-figure-body">
         <figure>
-				<figcaption><strong>Figure 8:</strong> Network peak demand breakdown - NPg Reference Scenario (MW)</figcaption>
+				<figcaption><strong>Figure 8:</strong> Network peak demand breakdown - Holistic Transition (MW)</figcaption>
 				<div class="table-holder">
 				<table>
 				<tr><th>Scenario</th><th>2030/31</th><th>2040/41</th><th>2050/51</th></tr>
@@ -1343,11 +1343,11 @@
 <article class="g-figure" id="figure-9" data-fig-num="9">
       <header class="g-figure-head">
         <div class="g-figure-num">Figure 9</div>
-        <h3 class="g-figure-title">Network energy consumption breakdown - NPg Reference Scenario (TWh)</h3>
+        <h3 class="g-figure-title">Network energy consumption breakdown - Holistic Transition (TWh)</h3>
       </header>
       <div class="g-figure-body">
         <figure>
-				<figcaption><strong>Figure 9:</strong> Network energy consumption breakdown - NPg Reference Scenario (TWh)</figcaption>
+				<figcaption><strong>Figure 9:</strong> Network energy consumption breakdown - Holistic Transition (TWh)</figcaption>
 				<div class="table-holder">
 				<table>
 				<tr><th>Scenario</th><th>2030/31</th><th>2040/41</th><th>2050/51</th></tr>
@@ -1822,11 +1822,11 @@
 <article class="g-figure" id="figure-11" data-fig-num="11">
       <header class="g-figure-head">
         <div class="g-figure-num">Figure 11</div>
-        <h3 class="g-figure-title">Additional industrial peak demand breakdown - NPg Reference Scenario (MW)</h3>
+        <h3 class="g-figure-title">Additional industrial peak demand breakdown - Holistic Transition (MW)</h3>
       </header>
       <div class="g-figure-body">
         <figure>
-				<figcaption><strong>Figure 11:</strong> Additional industrial peak demand breakdown - NPg Reference Scenario (MW)</figcaption>
+				<figcaption><strong>Figure 11:</strong> Additional industrial peak demand breakdown - Holistic Transition (MW)</figcaption>
 				<div class="table-holder">
 				<table>
 				<tr><th>Scenario</th><th>2030/31</th><th>2040/41</th><th>2050/51</th></tr>
@@ -1941,11 +1941,11 @@
 <article class="g-figure" id="figure-12" data-fig-num="12">
       <header class="g-figure-head">
         <div class="g-figure-num">Figure 12</div>
-        <h3 class="g-figure-title">Additional industrial energy consumption breakdown - NPg Reference Scenario (TWh)</h3>
+        <h3 class="g-figure-title">Additional industrial energy consumption breakdown - Holistic Transition (TWh)</h3>
       </header>
       <div class="g-figure-body">
         <figure>
-				<figcaption><strong>Figure 12:</strong> Additional industrial energy consumption breakdown - NPg Reference Scenario (TWh)</figcaption>
+				<figcaption><strong>Figure 12:</strong> Additional industrial energy consumption breakdown - Holistic Transition (TWh)</figcaption>
 				<div class="table-holder">
 				<table>
 				<tr><th>Scenario</th><th>2030/31</th><th>2040/41</th><th>2050/51</th></tr>

--- a/2026-DFES/graphs.html
+++ b/2026-DFES/graphs.html
@@ -945,11 +945,11 @@
       </header>
       <nav class="g-mini-toc" aria-label="Network demand graphs">
 <a href="#figure-7" class="g-mini-toc-item"><span>7</span> Annual peak demand (with ToUT) (GW)</a>
-<a href="#figure-8" class="g-mini-toc-item"><span>8</span> Network peak demand breakdown - NPg Reference Scenario (MW)</a>
-<a href="#figure-9" class="g-mini-toc-item"><span>9</span> Network energy consumption breakdown - NPg Reference Scenario (TWh)</a>
+<a href="#figure-8" class="g-mini-toc-item"><span>8</span> Network peak demand breakdown - Holistic Transition (MW)</a>
+<a href="#figure-9" class="g-mini-toc-item"><span>9</span> Network energy consumption breakdown - Holistic Transition (TWh)</a>
 <a href="#figure-10" class="g-mini-toc-item"><span>10</span> Annual network energy consumption (TWh)</a>
-<a href="#figure-11" class="g-mini-toc-item"><span>11</span> Additional industrial peak demand breakdown - NPg Reference Scenario (MW)</a>
-<a href="#figure-12" class="g-mini-toc-item"><span>12</span> Additional industrial energy consumption breakdown - NPg Reference Scenario (TWh)</a>
+<a href="#figure-11" class="g-mini-toc-item"><span>11</span> Additional industrial peak demand breakdown - Holistic Transition (MW)</a>
+<a href="#figure-12" class="g-mini-toc-item"><span>12</span> Additional industrial energy consumption breakdown - Holistic Transition (TWh)</a>
       </nav>
       <div class="g-figures">
 <article class="g-figure" id="figure-7" data-fig-num="7">
@@ -1107,11 +1107,11 @@
 <article class="g-figure" id="figure-8" data-fig-num="8">
       <header class="g-figure-head">
         <div class="g-figure-num">Figure 8</div>
-        <h3 class="g-figure-title">Network peak demand breakdown - NPg Reference Scenario (MW)</h3>
+        <h3 class="g-figure-title">Network peak demand breakdown - Holistic Transition (MW)</h3>
       </header>
       <div class="g-figure-body">
         <figure>
-				<figcaption><strong>Figure 8:</strong> Network peak demand breakdown - NPg Reference Scenario (MW)</figcaption>
+				<figcaption><strong>Figure 8:</strong> Network peak demand breakdown - Holistic Transition (MW)</figcaption>
 				<div class="table-holder">
 				<table>
 				<tr><th>Scenario</th><th>2030/31</th><th>2040/41</th><th>2050/51</th></tr>
@@ -1377,11 +1377,11 @@
 <article class="g-figure" id="figure-9" data-fig-num="9">
       <header class="g-figure-head">
         <div class="g-figure-num">Figure 9</div>
-        <h3 class="g-figure-title">Network energy consumption breakdown - NPg Reference Scenario (TWh)</h3>
+        <h3 class="g-figure-title">Network energy consumption breakdown - Holistic Transition (TWh)</h3>
       </header>
       <div class="g-figure-body">
         <figure>
-				<figcaption><strong>Figure 9:</strong> Network energy consumption breakdown - NPg Reference Scenario (TWh)</figcaption>
+				<figcaption><strong>Figure 9:</strong> Network energy consumption breakdown - Holistic Transition (TWh)</figcaption>
 				<div class="table-holder">
 				<table>
 				<tr><th>Scenario</th><th>2030/31</th><th>2040/41</th><th>2050/51</th></tr>
@@ -1856,11 +1856,11 @@
 <article class="g-figure" id="figure-11" data-fig-num="11">
       <header class="g-figure-head">
         <div class="g-figure-num">Figure 11</div>
-        <h3 class="g-figure-title">Additional industrial peak demand breakdown - NPg Reference Scenario (MW)</h3>
+        <h3 class="g-figure-title">Additional industrial peak demand breakdown - Holistic Transition (MW)</h3>
       </header>
       <div class="g-figure-body">
         <figure>
-				<figcaption><strong>Figure 11:</strong> Additional industrial peak demand breakdown - NPg Reference Scenario (MW)</figcaption>
+				<figcaption><strong>Figure 11:</strong> Additional industrial peak demand breakdown - Holistic Transition (MW)</figcaption>
 				<div class="table-holder">
 				<table>
 				<tr><th>Scenario</th><th>2030/31</th><th>2040/41</th><th>2050/51</th></tr>
@@ -1975,11 +1975,11 @@
 <article class="g-figure" id="figure-12" data-fig-num="12">
       <header class="g-figure-head">
         <div class="g-figure-num">Figure 12</div>
-        <h3 class="g-figure-title">Additional industrial energy consumption breakdown - NPg Reference Scenario (TWh)</h3>
+        <h3 class="g-figure-title">Additional industrial energy consumption breakdown - Holistic Transition (TWh)</h3>
       </header>
       <div class="g-figure-body">
         <figure>
-				<figcaption><strong>Figure 12:</strong> Additional industrial energy consumption breakdown - NPg Reference Scenario (TWh)</figcaption>
+				<figcaption><strong>Figure 12:</strong> Additional industrial energy consumption breakdown - Holistic Transition (TWh)</figcaption>
 				<div class="table-holder">
 				<table>
 				<tr><th>Scenario</th><th>2030/31</th><th>2040/41</th><th>2050/51</th></tr>

--- a/2026-DFES/index.html
+++ b/2026-DFES/index.html
@@ -59,7 +59,7 @@
 	<!-- Site header -->
 	<header class="site-header">
 		<div class="holder">
-			<a href="/" class="brand">
+			<a href="../" class="brand">
 				<img src="resources/npg-logo.svg" alt="Northern Powergrid" />
 				<span class="breadcrumb">Future Energy Scenarios <strong>2026</strong></span>
 			</a>
@@ -73,12 +73,6 @@
 		</div>
 	</header>
 
-	<div class="warning tallpadded">
-		<div class="holder">
-		<h2>WARNING</h2>
-		<p>This page is currently <em>under development</em>. It contains placeholder parameters, scenarios, data, and text.<br />The real DFES 2026 data will be included here later.</p>
-		</div>
-	</div>
 	<!-- Hero -->
 	<section class="hero">
 		<div class="holder">


### PR DESCRIPTION
Remove the under development banner from the index and map embed pages. Rename the single scenario breakdown graphs from NPg Reference Scenario to Holistic Transition. Point the index page header logo up one level instead of the site root. Align the map embed scenario description with the tRESP wording used elsewhere.

regenerated graphs included , but will regenerate on CI push 

Contributes towards #112 