### PR TITLE
Minor styling tweaks

### DIFF
--- a/2026-DFES/index.html
+++ b/2026-DFES/index.html
@@ -364,7 +364,7 @@
 					</div>
 					<div class="callout-num">
 						<div class="v">24</div>
-						<div class="l">Years of forecasts &mdash; from 2026 through 2050.</div>
+						<div class="l">Years of forecasts - from 2026 through to 2050.</div>
 					</div>
 					<div class="callout-num">
 						<div class="v">3</div>

--- a/2026-DFES/index.html
+++ b/2026-DFES/index.html
@@ -255,13 +255,13 @@
 					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>
 					Graphs
 				</a>
-				<a href="https://northernpowergrid.opendatasoft.com/explore/dataset/northern-powergrid-dfes/" class="issue-pill">
-					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-					Get the data
-				</a>
 				<a href="https://github.com/northernpowergrid/dfes/issues/" class="issue-pill">
 					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
 					Report an issue
+				</a>
+				<a href="https://northernpowergrid.opendatasoft.com/explore/dataset/northern-powergrid-dfes/" class="issue-pill issue-pill--cta">
+					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+					Get the data
 				</a>
 			</div>
 		</div>
@@ -368,7 +368,7 @@
 					</div>
 					<div class="callout-num">
 						<div class="v">3</div>
-						<div class="l">Scenarios stress-tested against ENA Open Networks.</div>
+						<div class="l">Scenarios stress-tested against NESO's transitional Regional Energy Strategic Plan.</div>
 					</div>
 				</div>
 			</div>

--- a/2026-DFES/resources/app.css
+++ b/2026-DFES/resources/app.css
@@ -2002,6 +2002,16 @@ a { color: inherit; }
 	color: var(--white);
 	border-color: var(--black-100);
 }
+.issue-pill--cta {
+	background: var(--red-100);
+	border-color: var(--red-100);
+	color: var(--white);
+}
+.issue-pill--cta:hover {
+	background: var(--warm-maroon);
+	border-color: var(--warm-maroon);
+	color: var(--white);
+}
 @media (max-width: 560px) {
 	#scenario > .holder > #issues { justify-content: stretch; }
 	.issue-pill { flex: 1 1 auto; justify-content: center; }


### PR DESCRIPTION
A few small layout and styling tweaks to the 2026 page

Updated the footer stat wording from "ENA Open Networks" to "NESO's transitional Regional Energy Strategic Plan"

Moved the "Get the data" button under the map to the right hand end and gave it a solid red treatment so it stands out from the other buttons.