### PR TITLE
Fix postcode search on the 2026 map

### DIFF
--- a/2026-DFES/resources/config.js
+++ b/2026-DFES/resources/config.js
@@ -423,14 +423,13 @@ OI.ready(function(){
 								postcode = m[0];
 								if(!postcodes[m[0]]){
 									postcodes[m[0]] = {};
-									AJAX('https://findthatpostcode.uk/postcodes/'+m[0]+'.json',{
-										'dataType':'json',
-										'postcode':m[0],
+									_obj.fetch('https://findthatpostcode.uk/postcodes/'+m[0]+'.json',{
+										'type':'json',
 										'this': e.data.me,
-										'success': function(data,attr){
-											postcodes[attr.postcode] = data;
+										'callback': function(data){
+											postcodes[m[0]] = data;
 											matchedprimary = findPrimary(_obj,data);
-											this.update();
+											e.data.me.update();
 										}
 									});
 								}else{


### PR DESCRIPTION
The postcode lookup called an AJAX helper that is not defined on the page, so entering a postcode threw a reference error and did nothing. Route the lookup through the map object's own fetch method instead.
Unsure if this was an issue introduced with the restying work, but fixed either way