### PR TITLE
Improve Year Control Labelling and Controls + Improve Map Zoom

### DIFF
--- a/2026-DFES/embed.html
+++ b/2026-DFES/embed.html
@@ -78,20 +78,12 @@
 				</div>
 
 				<div class="control-group">
-					<h3><span class="num">4</span> Year</h3>
+					<h3><span class="num">4</span> Select year</h3>
 					<div class="timeline">
 						<div class="timeline-head">
 							<div class="timeline-year">
 								<span class="small">Forecast</span>
 								<span class="year">&mdash;</span>
-							</div>
-							<div class="timeline-controls">
-								<button id="play" class="icon-btn" title="Play" aria-label="Play animation through years">
-									<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><polygon points="6 4 20 12 6 20 6 4"/></svg>
-								</button>
-								<button id="pause" class="icon-btn ghost" title="Pause" disabled aria-label="Pause animation">
-									<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/></svg>
-								</button>
 							</div>
 						</div>
 						<div class="scrubber">
@@ -106,6 +98,16 @@
 								<span class="scrubber-tick">2045</span>
 								<span class="scrubber-tick major">2050</span>
 							</div>
+						</div>
+						<div class="timeline-controls">
+							<button id="play" class="icon-btn" title="Play through the years on the timeline" aria-label="Play through the years on the timeline">
+								<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><polygon points="6 4 20 12 6 20 6 4"/></svg>
+								<span class="icon-btn-label">Play</span>
+							</button>
+							<button id="pause" class="icon-btn ghost" title="Pause on the current year" disabled aria-label="Pause on the current year">
+								<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/></svg>
+								<span class="icon-btn-label">Pause</span>
+							</button>
 						</div>
 					</div>
 				</div>

--- a/2026-DFES/index.html
+++ b/2026-DFES/index.html
@@ -179,20 +179,12 @@
 				</div>
 
 				<div class="control-group">
-					<h3><span class="num">4</span> Year</h3>
+					<h3><span class="num">4</span> Select year</h3>
 					<div class="timeline">
 						<div class="timeline-head">
 							<div class="timeline-year">
 								<span class="small">Forecast</span>
 								<span class="year">&mdash;</span>
-							</div>
-							<div class="timeline-controls">
-								<button id="play" class="icon-btn" title="Play" aria-label="Play animation through years">
-									<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><polygon points="6 4 20 12 6 20 6 4"/></svg>
-								</button>
-								<button id="pause" class="icon-btn ghost" title="Pause" disabled aria-label="Pause animation">
-									<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/></svg>
-								</button>
 							</div>
 						</div>
 						<div class="scrubber">
@@ -207,6 +199,16 @@
 								<span class="scrubber-tick">2045</span>
 								<span class="scrubber-tick major">2050</span>
 							</div>
+						</div>
+						<div class="timeline-controls">
+							<button id="play" class="icon-btn" title="Play through the years on the timeline" aria-label="Play through the years on the timeline">
+								<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><polygon points="6 4 20 12 6 20 6 4"/></svg>
+								<span class="icon-btn-label">Play</span>
+							</button>
+							<button id="pause" class="icon-btn ghost" title="Pause on the current year" disabled aria-label="Pause on the current year">
+								<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/></svg>
+								<span class="icon-btn-label">Pause</span>
+							</button>
 						</div>
 					</div>
 				</div>

--- a/2026-DFES/resources/app.css
+++ b/2026-DFES/resources/app.css
@@ -1812,9 +1812,10 @@ a { color: inherit; }
 .timeline-controls {
 	display: flex;
 	gap: 8px;
+	margin-top: 8px; /* breathing room below the scrubber tick labels */
 }
 .icon-btn {
-	width: 30px;
+	width: auto; /* the design-reference block earlier fixes width at 36px; these are pills now */
 	height: 30px;
 	border-radius: 999px;
 	background: var(--black-100);
@@ -1822,11 +1823,14 @@ a { color: inherit; }
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
+	gap: 6px;
 	transition: background var(--dur-fast);
 	border: 0;
 	cursor: pointer;
-	padding: 0;
-	font-size: 0; /* hide any text content (existing buttons have ▶/⏸ glyphs) */
+	padding: 0 14px;
+	font-size: 12px;
+	font-weight: 600;
+	letter-spacing: 0.02em;
 }
 @media (hover: hover) { .icon-btn:hover:not(:disabled) { background: var(--red-100); } }
 .icon-btn:disabled { opacity: 0.4; cursor: not-allowed; }
@@ -1836,18 +1840,21 @@ a { color: inherit; }
 	border: 1.5px solid var(--navy-20);
 }
 @media (hover: hover) { .icon-btn.ghost:hover:not(:disabled) { background: var(--black-5); } }
-.icon-btn svg { width: 14px; height: 14px; display: block; }
+.icon-btn svg { width: 14px; height: 14px; display: block; flex: none; }
 
 /* Scrubber, custom track/fill/thumb on top of the existing <input range> */
 .scrubber {
 	position: relative;
-	height: 36px;
+	height: 42px;
 	user-select: none;
 }
 .scrubber-track {
 	position: absolute;
-	left: 0;
-	right: 0;
+	/* Inset by half the 26px thumb so the thumb's travel (set with a
+	   matching calc() in controls.js) stays inside the control; at the
+	   ends the thumb edge lines up with the first and last tick labels. */
+	left: 13px;
+	right: 13px;
 	top: 14px;
 	height: 6px;
 	background: var(--navy-10);
@@ -1863,13 +1870,13 @@ a { color: inherit; }
 }
 .scrubber-thumb {
 	position: absolute;
-	top: 8px;
-	left: 0;
-	width: 18px;
-	height: 18px;
+	top: 4px;
+	left: 13px; /* start-of-track centre; controls.js takes over from here */
+	width: 26px;
+	height: 26px;
 	border-radius: 999px;
 	background: var(--white);
-	border: 3px solid var(--red-100);
+	border: 4px solid var(--red-100);
 	transform: translateX(-50%);
 	cursor: grab;
 	box-shadow: 0 1px 4px rgba(0,0,0,0.15);
@@ -1904,7 +1911,7 @@ a { color: inherit; }
 	position: absolute;
 	left: 0;
 	right: 0;
-	top: 24px;
+	top: 30px;
 	display: flex;
 	justify-content: space-between;
 	pointer-events: none;

--- a/2026-DFES/resources/config.js
+++ b/2026-DFES/resources/config.js
@@ -279,28 +279,41 @@ OI.ready(function(){
 				if(this.map && !this._mapViewportReady){
 					this._mapViewportReady = true;
 
-					this.map.invalidateSize({animate:false});
-
-					var unionBounds = null;
-					for(var lid in this.layers){
-						var lyr = this.layers[lid] && this.layers[lid].layer;
-						if(lyr && typeof lyr.getBounds==="function"){
-							var b = lyr.getBounds();
-							if(b && b.isValid()){
-								if(!unionBounds) unionBounds = L.latLngBounds(b.getSouthWest(), b.getNorthEast());
-								else unionBounds.extend(b);
+					var fitRegion = function(){
+						_obj.map.invalidateSize({animate:false});
+						var unionBounds = null;
+						for(var lid in _obj.layers){
+							var lyr = _obj.layers[lid] && _obj.layers[lid].layer;
+							if(lyr && typeof lyr.getBounds==="function"){
+								var b = lyr.getBounds();
+								if(b && b.isValid()){
+									if(!unionBounds) unionBounds = L.latLngBounds(b.getSouthWest(), b.getNorthEast());
+									else unionBounds.extend(b);
+								}
 							}
 						}
-					}
-					if(unionBounds && unionBounds.isValid()){
-						this.map.fitBounds(unionBounds,{padding:[20,20]});
-					}
+						if(unionBounds && unionBounds.isValid()){
+							_obj.map.fitBounds(unionBounds,{padding:[20,20],animate:false});
+						}
+					};
+					fitRegion();
 
+					// The container is often still growing when the first
+					// fit runs (left column populates, fonts load), which
+					// locks in a zoom computed for a smaller map. Keep the
+					// region framed on each resize until the user pans or
+					// zooms themselves, then only re-measure.
+					var container = this.map.getContainer();
+					var userMoved = function(){ _obj._mapUserMoved = true; };
+					container.addEventListener('pointerdown', userMoved);
+					container.addEventListener('wheel', userMoved);
 					if(typeof ResizeObserver!=="undefined"){
 						var ro = new ResizeObserver(function(){
-							if(_obj.map) _obj.map.invalidateSize({animate:false});
+							if(!_obj.map) return;
+							if(_obj._mapUserMoved) _obj.map.invalidateSize({animate:false});
+							else fitRegion();
 						});
-						ro.observe(this.map.getContainer());
+						ro.observe(container);
 						this._mapResizeObserver = ro;
 					}
 				}

--- a/2026-DFES/resources/controls.js
+++ b/2026-DFES/resources/controls.js
@@ -183,7 +183,10 @@
 			var pct = (max === min) ? 0 : ((v - min) / (max - min)) * 100;
 			pct = Math.max(0, Math.min(100, pct));
 			if (fill) fill.style.width = pct + '%';
-			if (thumb) thumb.style.left = pct + '%';
+			// Keep the thumb's travel inside the control: the track is
+			// inset 13px (half the 26px thumb) each side in app.css, so
+			// the thumb centre runs from 13px to (100% - 13px).
+			if (thumb) thumb.style.left = 'calc(13px + ' + (pct / 100) + ' * (100% - 26px))';
 			// Accessibility, dfes.js doesn't set these.
 			slider.setAttribute('aria-valuemin', String(min));
 			slider.setAttribute('aria-valuemax', String(max));

--- a/2026-DFES/resources/dfes.js
+++ b/2026-DFES/resources/dfes.js
@@ -823,7 +823,10 @@
 		if(!this.map){
 			mapel = document.getElementById('map');
 			mapid = mapel.getAttribute('id');
-			this.map = L.map(mapid,{'scrollWheelZoom':true}).fitBounds(bounds);
+			// Fractional zoom: zoomSnap lets fitBounds frame the region
+			// tightly instead of rounding down to a whole zoom level,
+			// zoomDelta and wheelPxPerZoomLevel give finer zoom steps.
+			this.map = L.map(mapid,{'scrollWheelZoom':true,'zoomSnap':0.25,'zoomDelta':0.5,'wheelPxPerZoomLevel':150}).fitBounds(bounds);
 			this.map.on('popupopen',function(e){
 				// Call any attached functions
 				if(_obj.views[_obj.options.view].popup && _obj.views[_obj.options.view].popup.open){


### PR DESCRIPTION
Relabelled the year controls, moved the play and pause buttons with clearer labelling, increased the size of the timeline thumb handle control.

In addition set finer zoom steps on the map and set a slightly different starting position to improve the fill of the map in the default viewport. A bit of extra code to get the viewport to scale correctly on page first draw .

addresses points 3 and 4 in #121