### PR TITLE
Fix graphs page sticky tabs clipping under the site header

### DIFF
--- a/2026-DFES/graphs-embed.html
+++ b/2026-DFES/graphs-embed.html
@@ -9,7 +9,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
 <link rel="stylesheet" href="resources/tokens.css?v=1"/>
 <link rel="stylesheet" href="resources/app.css?v=6"/>
-<link rel="stylesheet" href="resources/graphs.css?v=2"/>
+<link rel="stylesheet" href="resources/graphs.css?v=3"/>
 <link rel="icon" href="resources/icons/favicon.ico" sizes="any"/>
 <link rel="icon" type="image/svg+xml" href="resources/icons/favicon.svg"/>
 <link rel="icon" type="image/png" sizes="32x32" href="resources/icons/favicon-32.png"/>

--- a/2026-DFES/graphs.html
+++ b/2026-DFES/graphs.html
@@ -9,7 +9,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
 <link rel="stylesheet" href="resources/tokens.css?v=1"/>
 <link rel="stylesheet" href="resources/app.css?v=6"/>
-<link rel="stylesheet" href="resources/graphs.css?v=2"/>
+<link rel="stylesheet" href="resources/graphs.css?v=3"/>
 <link rel="icon" href="resources/icons/favicon.ico" sizes="any"/>
 <link rel="icon" type="image/svg+xml" href="resources/icons/favicon.svg"/>
 <link rel="icon" type="image/png" sizes="32x32" href="resources/icons/favicon-32.png"/>

--- a/2026-DFES/resources/graphs.css
+++ b/2026-DFES/resources/graphs.css
@@ -42,7 +42,7 @@
 .g-tabs {
   background: var(--black-100);
   position: sticky;
-  top: 64px;
+  top: 76px; /* matches .site-header .holder height; smaller values clip the tabs under it */
   z-index: 40;
   border-bottom: 1px solid var(--navy-25);
 }
@@ -94,6 +94,9 @@
   font-weight: 600;
 }
 .g-tab.active .g-tab-count { background: var(--red-100); color: var(--white); }
+
+/* Keep anchor targets clear of the sticky header + tabs (76px + ~60px) */
+.g-panel, .g-figure { scroll-margin-top: 150px; }
 
 /* ===================================================================
    Section panels; only the active one is shown
@@ -320,7 +323,6 @@
    Responsive
    =================================================================== */
 @media (max-width: 840px) {
-  .g-tabs { top: 56px; }
   .g-tab { padding: 14px 14px; gap: 8px; }
   .g-tab-label { font-size: 13px; }
   .g-tab-count { display: none; }


### PR DESCRIPTION
Pin the tab bar at the full 76px header height so the labels are not cut off when scrolling on mobile, and add scroll margins so anchor links land clear of the sticky bars. Bump the stylesheet version.